### PR TITLE
perf: code-split layman-law-app bundle + silence ESM warnings

### DIFF
--- a/layman-law-app/package.json
+++ b/layman-law-app/package.json
@@ -2,6 +2,7 @@
   "name": "layman-law-app",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/layman-law-app/vite.config.ts
+++ b/layman-law-app/vite.config.ts
@@ -35,4 +35,15 @@ export default defineConfig({
       },
     }),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+          'supabase':     ['@supabase/supabase-js'],
+          'icons':        ['lucide-react'],
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
- vite.config: add manualChunks (react-vendor, supabase, icons) reduces single 620KB chunk into smaller cacheable bundles
- package.json: add "type": "module" silences postcss.config.js CJS-vs-ESM reparse warning at build